### PR TITLE
split the methods

### DIFF
--- a/Assets/Scripts/Dialogue/InkManager.cs
+++ b/Assets/Scripts/Dialogue/InkManager.cs
@@ -152,7 +152,7 @@ public class InkManager : MonoBehaviour
                 case XP_TAG:
                     if(dialogue.XPTriggered == false){
                         dialogue.XPTriggered = true;
-                        ExperienceManager.Instance.AddExperience((GetXPTagValue(tag)), story.currentText);
+                        ExperienceManager.Instance.AddDialogueExperience((GetXPTagValue(tag)), story.currentText);
                     }
                     else
                         Debug.Log("XP reward already triggered for this dialogue");

--- a/Assets/Scripts/Managers/ExperienceManager.cs
+++ b/Assets/Scripts/Managers/ExperienceManager.cs
@@ -63,7 +63,17 @@ public class ExperienceManager : MonoBehaviour
         return level;
     }
 
-    public void AddExperience(int pXP, string rewardText = null)
+    public void AddExperience(int pXP)
+    {
+        Debug.Log("Adding XP");
+        currentExperience += pXP;
+
+        PlayerPrefs.SetInt(GetCurrentLevel(), currentExperience);
+
+        OnExperienceChange?.Invoke(currentExperience);
+    }
+
+    public void AddDialogueExperience(int pXP, string rewardText = null)
     {
         if (rewardText != null && rewardedText.Contains(rewardText))
             return;


### PR DESCRIPTION
the second parameter was even optional but unity events did not care I guess